### PR TITLE
Performance / Fix / Refactor : 그룹 삭제시의 성능 개선 및 삭제 후 올바르게 정렬이 안되는 문제 등

### DIFF
--- a/src/app/(main)/_shared/session/SessionContainer.tsx
+++ b/src/app/(main)/_shared/session/SessionContainer.tsx
@@ -63,6 +63,7 @@ const SessionContainer = ({
     updateMultipleDetailsInGroups,
     addDetailToGroup,
     removeDetailFromGroup,
+    removeMultipleDetailsInGroup,
   } = useLoadDetails({
     type,
     userId: userId ?? "",
@@ -299,7 +300,8 @@ const SessionContainer = ({
               <div className="flex items-center gap-2">
                 <span className="text-sm text-text-muted">총 볼륨</span>
                 <span className="text-lg font-semibold">
-                  {totalCurrentVolume.toLocaleString()}{weightUnit}
+                  {totalCurrentVolume.toLocaleString()}
+                  {weightUnit}
                 </span>
               </div>
             </div>
@@ -311,6 +313,7 @@ const SessionContainer = ({
                 key={`${exerciseOrder}-${details[0]?.exerciseId}`}
                 details={details}
                 reorderAfterDelete={reorderAfterDelete}
+                removeMultipleDetailsInGroup={removeMultipleDetailsInGroup}
                 occurrence={occurrenceData.get(exerciseOrder)}
                 exerciseOrder={exerciseOrder}
                 reload={reload}

--- a/src/app/(main)/_shared/session/SessionContainer.tsx
+++ b/src/app/(main)/_shared/session/SessionContainer.tsx
@@ -7,12 +7,18 @@ import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { Trash2, ChevronsUpDown } from "lucide-react";
 
-import useLoadDetails from "@/hooks/useLoadDetails";
+import useLoadDetails, { SessionGroup } from "@/hooks/useLoadDetails";
 
 import { useModal } from "@/providers/contexts/ModalContext";
 import ErrorState from "@/components/ErrorState";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useMemo, useCallback } from "react";
+import {
+  useEffect,
+  useMemo,
+  useCallback,
+  createContext,
+  useContext,
+} from "react";
 import {
   routineDetailService,
   routineService,
@@ -27,6 +33,7 @@ import {
   LocalWorkout,
   LocalWorkoutDetail,
   LocalRoutineDetail,
+  Saved,
 } from "@/types/models";
 import SessionExerciseGroup from "@/app/(main)/_shared/session/exerciseGroup/SessionExerciseGroup";
 import SessionSequence from "@/app/(main)/_shared/session/sessionSequence/SessionSequence";
@@ -42,6 +49,40 @@ type SessionContainerProps = {
   routineId?: number;
   date?: string;
   formattedDate?: string | React.ReactNode;
+};
+
+export type SessionData = {
+  sessionGroup: SessionGroup[];
+  updateDetailInGroups: (
+    updatedDetail: Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>
+  ) => void;
+  removeMultipleDetailsInGroup: (
+    details: Saved<LocalWorkoutDetail>[] | Saved<LocalRoutineDetail>[]
+  ) => void;
+  addDetailToGroup: (
+    newDetail: Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>,
+    lastDetail: Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>
+  ) => void;
+  removeDetailFromGroup: (detailId: number) => void;
+  updateMultipleDetailsInGroups: (
+    updatedDetails: Saved<LocalWorkoutDetail>[] | Saved<LocalRoutineDetail>[]
+  ) => void;
+  reload: () => Promise<void>;
+  reorderExerciseOrderAfterDelete: (
+    deletedExerciseOrder: number
+  ) => Promise<void>;
+  reorderSetOrderAfterDelete: (
+    exerciseId: number,
+    deletedSetOrder: number
+  ) => Promise<void>;
+};
+const SessionDataContext = createContext<SessionData | null>(null);
+
+export const useSessionData = () => {
+  const context = useContext(SessionDataContext);
+  if (!context)
+    throw new Error("useSessionData must be used within SessionContainer");
+  return context;
 };
 
 const SessionContainer = ({
@@ -110,7 +151,7 @@ const SessionContainer = ({
     });
   }, [openBottomSheet, type, routineId, workoutGroups.length, date, reload]);
 
-  const reorderAfterDelete = useCallback(
+  const reorderExerciseOrderAfterDelete = useCallback(
     async (deletedExerciseOrder: number): Promise<void> => {
       try {
         let latestDetails: (LocalWorkoutDetail | LocalRoutineDetail)[] = [];
@@ -148,6 +189,53 @@ const SessionContainer = ({
       }
     },
     [type, userId, date, routineId, showError]
+  );
+  const reorderSetOrderAfterDelete = useCallback(
+    async (exerciseId: number, deletedSetOrder: number): Promise<void> => {
+      try {
+        let latestDetails: (
+          | Saved<LocalWorkoutDetail>
+          | Saved<LocalRoutineDetail>
+        )[] = [];
+
+        if (type === "RECORD" && userId && date) {
+          latestDetails = await workoutDetailService.getLocalWorkoutDetails(
+            userId,
+            date
+          );
+        } else if (type === "ROUTINE" && routineId) {
+          latestDetails =
+            await routineDetailService.getLocalRoutineDetails(routineId);
+        }
+
+        const affectedDetails = latestDetails.filter(
+          (d) => d.exerciseId === exerciseId && d.setOrder > deletedSetOrder
+        );
+
+        const updatedDetails = affectedDetails.map((detail) => ({
+          ...detail,
+          setOrder: detail.setOrder - 1,
+        }));
+
+        await Promise.all(
+          updatedDetails.map((detail) => {
+            if (isWorkoutDetail(detail)) {
+              return workoutDetailService.updateLocalWorkoutDetail(detail);
+            } else {
+              return routineDetailService.updateLocalRoutineDetail(detail);
+            }
+          })
+        );
+
+        if (updatedDetails.length > 0) {
+          updateMultipleDetailsInGroups(updatedDetails);
+        }
+      } catch (e) {
+        console.error("[SessionContainer] reorderSetOrderAfterDelete Error", e);
+        showError("세트 순서 업데이트에 실패했습니다");
+      }
+    },
+    [type, userId, date, routineId, showError, updateMultipleDetailsInGroups]
   );
 
   const handleDeleteAll = useCallback(async () => {
@@ -262,104 +350,124 @@ const SessionContainer = ({
     return () => window.removeEventListener("popstate", handlePopState);
   }, [pathname, isModalOpen]);
 
+  const contextValue = useMemo(
+    () => ({
+      sessionGroup: workoutGroups,
+      updateDetailInGroups,
+      removeMultipleDetailsInGroup,
+      addDetailToGroup,
+      removeDetailFromGroup,
+      updateMultipleDetailsInGroups,
+      reorderExerciseOrderAfterDelete,
+      reorderSetOrderAfterDelete,
+      reload,
+    }),
+    [
+      workoutGroups,
+      updateDetailInGroups,
+      removeMultipleDetailsInGroup,
+      addDetailToGroup,
+      removeDetailFromGroup,
+      updateMultipleDetailsInGroups,
+      reorderExerciseOrderAfterDelete,
+      reorderSetOrderAfterDelete,
+      reload,
+    ]
+  );
+
   if (isLoading) return null;
   if (error) return <ErrorState error={error} onRetry={reload} />;
   return (
-    <div>
-      {workoutGroups.length !== 0 ? (
-        <>
-          {(formattedDate || type === "ROUTINE") && (
-            <div className="flex justify-between items-center mb-6 ">
-              {formattedDate &&
-                (typeof formattedDate === "string" ? (
-                  <time className="text-2xl font-bold">{formattedDate}</time>
-                ) : (
-                  <div className="text-2xl font-bold">{formattedDate}</div>
-                ))}
-              <div className="flex gap-2">
-                <button
-                  onClick={handleDeleteAll}
-                  className="p-2 hover:bg-bg-surface rounded-lg transition-colors"
-                  aria-label="전체 삭제"
-                >
-                  <Trash2 className="w-6 h-6 text-text-muted" />
-                </button>
-                <button
-                  onClick={handleOpenSequenceSheet}
-                  className="p-2 hover:bg-bg-surface rounded-lg transition-colors"
-                  aria-label="순서 변경"
-                >
-                  <ChevronsUpDown className="w-6 h-6 text-text-muted" />
-                </button>
+    <SessionDataContext.Provider value={contextValue}>
+      <div>
+        {workoutGroups.length !== 0 ? (
+          <>
+            {(formattedDate || type === "ROUTINE") && (
+              <div className="flex justify-between items-center mb-6 ">
+                {formattedDate &&
+                  (typeof formattedDate === "string" ? (
+                    <time className="text-2xl font-bold">{formattedDate}</time>
+                  ) : (
+                    <div className="text-2xl font-bold">{formattedDate}</div>
+                  ))}
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleDeleteAll}
+                    className="p-2 hover:bg-bg-surface rounded-lg transition-colors"
+                    aria-label="전체 삭제"
+                  >
+                    <Trash2 className="w-6 h-6 text-text-muted" />
+                  </button>
+                  <button
+                    onClick={handleOpenSequenceSheet}
+                    className="p-2 hover:bg-bg-surface rounded-lg transition-colors"
+                    aria-label="순서 변경"
+                  >
+                    <ChevronsUpDown className="w-6 h-6 text-text-muted" />
+                  </button>
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {workoutGroups.length > 0 && (
-            <div className="bg-bg-surface rounded-lg p-3 mb-4">
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-text-muted">총 볼륨</span>
-                <span className="text-lg font-semibold">
-                  {totalCurrentVolume.toLocaleString()}
-                  {weightUnit}
-                </span>
+            {workoutGroups.length > 0 && (
+              <div className="bg-bg-surface rounded-lg p-3 mb-4">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-text-muted">총 볼륨</span>
+                  <span className="text-lg font-semibold">
+                    {totalCurrentVolume.toLocaleString()}
+                    {weightUnit}
+                  </span>
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          <ul className="flex flex-col gap-2.5 scrollbar-none">
-            {workoutGroups.map(({ exerciseOrder, details }) => (
-              <SessionExerciseGroup
-                key={`${exerciseOrder}-${details[0]?.exerciseId}`}
-                details={details}
-                reorderAfterDelete={reorderAfterDelete}
-                removeMultipleDetailsInGroup={removeMultipleDetailsInGroup}
-                occurrence={occurrenceData.get(exerciseOrder)}
-                exerciseOrder={exerciseOrder}
-                reload={reload}
-                updateDetailInGroups={updateDetailInGroups}
-                updateMultipleDetailsInGroups={updateMultipleDetailsInGroups}
-                removeDetailFromGroup={removeDetailFromGroup}
-                addDetailToGroup={addDetailToGroup}
-              />
-            ))}
-          </ul>
+            <ul className="flex flex-col gap-2.5 scrollbar-none">
+              {workoutGroups.map(({ exerciseOrder, details }) => (
+                <SessionExerciseGroup
+                  key={`${exerciseOrder}-${details[0]?.exerciseId}`}
+                  details={details}
+                  occurrence={occurrenceData.get(exerciseOrder)}
+                  exerciseOrder={exerciseOrder}
+                />
+              ))}
+            </ul>
 
-          <div className="flex gap-2 mt-2">
-            <Link
-              href={exercisePath}
-              replace
-              className="flex-1 py-2.5 bg-bg-surface text-sm rounded-lg text-center hover:bg-bg-surface-variant transition-colors"
-            >
-              운동 추가
-            </Link>
-            <button
-              onClick={handleOpenLocalWorkoutSheet}
-              className="flex-1 py-2.5 bg-bg-surface text-sm rounded-lg hover:bg-bg-surface-variant transition-colors"
-            >
-              불러오기
-            </button>
-          </div>
-          {type === "RECORD" && workout?.status !== "COMPLETED" && (
-            <button
-              onClick={handleClickCompleteBtn}
-              className="w-full mt-6 py-3 bg-primary text-text-black font-semibold rounded-xl hover:bg-primary/90 active:scale-[0.98] transition-all duration-200"
-            >
-              운동 완료
-            </button>
-          )}
-        </>
-      ) : (
-        <>
-          {formattedDate && (
-            <div className="mb-6">
-              <time className="text-2xl font-bold">{formattedDate}</time>
+            <div className="flex gap-2 mt-2">
+              <Link
+                href={exercisePath}
+                replace
+                className="flex-1 py-2.5 bg-bg-surface text-sm rounded-lg text-center hover:bg-bg-surface-variant transition-colors"
+              >
+                운동 추가
+              </Link>
+              <button
+                onClick={handleOpenLocalWorkoutSheet}
+                className="flex-1 py-2.5 bg-bg-surface text-sm rounded-lg hover:bg-bg-surface-variant transition-colors"
+              >
+                불러오기
+              </button>
             </div>
-          )}
-          <SessionPlaceholder reloadDetails={reload} {...placeholderProps} />
-        </>
-      )}
-    </div>
+            {type === "RECORD" && workout?.status !== "COMPLETED" && (
+              <button
+                onClick={handleClickCompleteBtn}
+                className="w-full mt-6 py-3 bg-primary text-text-black font-semibold rounded-xl hover:bg-primary/90 active:scale-[0.98] transition-all duration-200"
+              >
+                운동 완료
+              </button>
+            )}
+          </>
+        ) : (
+          <>
+            {formattedDate && (
+              <div className="mb-6">
+                <time className="text-2xl font-bold">{formattedDate}</time>
+              </div>
+            )}
+            <SessionPlaceholder reloadDetails={reload} {...placeholderProps} />
+          </>
+        )}
+      </div>
+    </SessionDataContext.Provider>
   );
 };
 

--- a/src/app/(main)/_shared/session/exerciseGroup/SessionDetailGroupOptions.spec.tsx
+++ b/src/app/(main)/_shared/session/exerciseGroup/SessionDetailGroupOptions.spec.tsx
@@ -54,6 +54,7 @@ describe("SessionDetailGroupOptions", () => {
   const mockReload = jest.fn();
   const mockReorderAfterDelete = jest.fn();
   const mockUpdateMultipleDetailsInGroups = jest.fn();
+  const mockRemoveMultipleDetailsInGroup = jest.fn();
 
   const mockExerciseData: Saved<LocalExercise> = {
     ...mockExercise.list[0],
@@ -109,6 +110,7 @@ describe("SessionDetailGroupOptions", () => {
       reload: mockReload,
       reorderAfterDelete: mockReorderAfterDelete,
       updateMultipleDetailsInGroups: mockUpdateMultipleDetailsInGroups,
+      removeMultipleDetailsInGroup: mockRemoveMultipleDetailsInGroup,
       ...props,
     };
 
@@ -205,7 +207,9 @@ describe("SessionDetailGroupOptions", () => {
         expect(
           mockWorkoutDetailService.deleteWorkoutDetails
         ).toHaveBeenCalledWith(mockWorkoutDetails);
-        expect(mockReload).toHaveBeenCalledTimes(1);
+        expect(mockRemoveMultipleDetailsInGroup).toHaveBeenCalledWith(
+          mockWorkoutDetails
+        );
       });
     });
 
@@ -224,7 +228,9 @@ describe("SessionDetailGroupOptions", () => {
         expect(
           mockRoutineDetailService.deleteRoutineDetails
         ).toHaveBeenCalledWith(mockRoutineDetails);
-        expect(mockReload).toHaveBeenCalledTimes(1);
+        expect(mockRemoveMultipleDetailsInGroup).toHaveBeenCalledWith(
+          mockRoutineDetails
+        );
       });
     });
 

--- a/src/app/(main)/_shared/session/exerciseGroup/SessionDetailGroupOptions.spec.tsx
+++ b/src/app/(main)/_shared/session/exerciseGroup/SessionDetailGroupOptions.spec.tsx
@@ -21,7 +21,6 @@ jest.mock("framer-motion", () => ({
 import { mockExercise } from "@/__mocks__/exercise.mock";
 import { mockWorkoutDetail } from "@/__mocks__/workoutDetail.mock";
 import { mockRoutineDetail } from "@/__mocks__/routineDetail.mock";
-import SessionDetailGroupOptions from "./SessionDetailGroupOptions";
 import { useModal } from "@/providers/contexts/ModalContext";
 import { useBottomSheet } from "@/providers/contexts/BottomSheetContext";
 import {
@@ -38,6 +37,9 @@ import {
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { KG_TO_LBS } from "@/util/weightConversion";
+import SessionDetailGroupOptions, {
+  SessionDetailGroupOptionsProps,
+} from "@/app/(main)/_shared/session/exerciseGroup/SessionDetailGroupOptions";
 
 const mockUseModal = jest.mocked(useModal);
 const mockUseBottomSheet = jest.mocked(useBottomSheet);
@@ -52,7 +54,7 @@ describe("SessionDetailGroupOptions", () => {
   const mockShowError = jest.fn();
   const mockLoadExercises = jest.fn();
   const mockReload = jest.fn();
-  const mockReorderAfterDelete = jest.fn();
+  const mockReorderExerciseOrderAfterDelete = jest.fn();
   const mockUpdateMultipleDetailsInGroups = jest.fn();
   const mockRemoveMultipleDetailsInGroup = jest.fn();
 
@@ -93,24 +95,19 @@ describe("SessionDetailGroupOptions", () => {
     mockRoutineDetailService.updateLocalRoutineDetail.mockResolvedValue();
   });
 
-  const renderSessionDetailGroupOptions = (props?: {
-    exercise?: Saved<LocalExercise>;
-    details?: Saved<LocalWorkoutDetail>[] | Saved<LocalRoutineDetail>[];
-    loadExercises?: () => Promise<void>;
-    reload?: () => Promise<void>;
-    reorderAfterDelete?: (deletedExerciseOrder: number) => Promise<void>;
-    updateMultipleDetailsInGroups?: (
-      updatedDetails: (Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>)[]
-    ) => void;
-  }) => {
-    const defaultProps = {
+  const renderSessionDetailGroupOptions = (
+    props?: Partial<SessionDetailGroupOptionsProps>
+  ) => {
+    const defaultProps: SessionDetailGroupOptionsProps = {
       exercise: mockExerciseData,
+      exerciseOrder: 1,
+      reorderExerciseOrderAfterDelete: mockReorderExerciseOrderAfterDelete,
       details: mockWorkoutDetails,
       loadExercises: mockLoadExercises,
       reload: mockReload,
-      reorderAfterDelete: mockReorderAfterDelete,
       updateMultipleDetailsInGroups: mockUpdateMultipleDetailsInGroups,
       removeMultipleDetailsInGroup: mockRemoveMultipleDetailsInGroup,
+
       ...props,
     };
 
@@ -199,7 +196,10 @@ describe("SessionDetailGroupOptions", () => {
         onConfirm?.();
       });
 
-      renderSessionDetailGroupOptions({ details: mockWorkoutDetails });
+      renderSessionDetailGroupOptions({
+        details: mockWorkoutDetails,
+        exerciseOrder: 10,
+      });
 
       await user.click(screen.getByText("삭제하기"));
 
@@ -207,6 +207,8 @@ describe("SessionDetailGroupOptions", () => {
         expect(
           mockWorkoutDetailService.deleteWorkoutDetails
         ).toHaveBeenCalledWith(mockWorkoutDetails);
+
+        expect(mockReorderExerciseOrderAfterDelete).toHaveBeenCalledWith(10);
         expect(mockRemoveMultipleDetailsInGroup).toHaveBeenCalledWith(
           mockWorkoutDetails
         );

--- a/src/app/(main)/_shared/session/exerciseGroup/SessionDetailGroupOptions.tsx
+++ b/src/app/(main)/_shared/session/exerciseGroup/SessionDetailGroupOptions.tsx
@@ -37,6 +37,9 @@ type SessionDetailGroupOptions = {
   updateMultipleDetailsInGroups: (
     updatedDetails: (Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>)[]
   ) => void;
+  removeMultipleDetailsInGroup: (
+    details: Saved<LocalWorkoutDetail>[] | Saved<LocalRoutineDetail>[]
+  ) => void;
 };
 
 const units = ["kg", "lbs"] as const;
@@ -47,6 +50,7 @@ const SessionDetailGroupOptions = ({
   loadExercises,
   reload,
   updateMultipleDetailsInGroups,
+  removeMultipleDetailsInGroup,
 }: SessionDetailGroupOptions) => {
   const [unit, setUnit] = useState<(typeof units)[number]>(
     details[0]?.weightUnit || "kg"
@@ -79,7 +83,7 @@ const SessionDetailGroupOptions = ({
       } else {
         await routineDetailService.deleteRoutineDetails(details);
       }
-      await reload();
+      removeMultipleDetailsInGroup(details);
     } catch (e) {
       console.error(
         "[SessionDetailGroupOptions] deleteAndLoadDetails Error",

--- a/src/app/(main)/_shared/session/exerciseGroup/SessionDetailGroupOptions.tsx
+++ b/src/app/(main)/_shared/session/exerciseGroup/SessionDetailGroupOptions.tsx
@@ -18,43 +18,45 @@ import {
   isWorkoutDetail,
   isWorkoutDetails,
 } from "@/app/(main)/workout/_utils/checkIsWorkoutDetails";
-import {
-  exerciseService,
-  routineDetailService,
-  workoutDetailService,
-} from "@/lib/di";
+import { routineDetailService, workoutDetailService } from "@/lib/di";
 import ExerciseMemo from "@/app/(main)/_shared/session/exerciseMemo/ExerciseMemo";
 import GroupOptionItem from "@/app/(main)/_shared/session/exerciseGroup/GroupOptionItem";
 import { convertKgtoLbs, convertLbstoKg } from "@/util/weightConversion";
+import { useSessionData } from "@/app/(main)/_shared/session/SessionContainer";
 
-type SessionDetailGroupOptions = {
+export type SessionDetailGroupOptionsProps = {
   exercise: Saved<LocalExercise>;
+  exerciseOrder: number;
   details: Saved<LocalWorkoutDetail>[] | Saved<LocalRoutineDetail>[];
-
   loadExercises: () => Promise<void>;
   reload: () => Promise<void>;
-  reorderAfterDelete: (deletedExerciseOrder: number) => Promise<void>;
   updateMultipleDetailsInGroups: (
-    updatedDetails: (Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>)[]
+    updatedDetails: Saved<LocalWorkoutDetail>[] | Saved<LocalRoutineDetail>[]
   ) => void;
   removeMultipleDetailsInGroup: (
     details: Saved<LocalWorkoutDetail>[] | Saved<LocalRoutineDetail>[]
   ) => void;
+  reorderExerciseOrderAfterDelete: (
+    deletedExerciseOrder: number
+  ) => Promise<void>;
 };
 
 const units = ["kg", "lbs"] as const;
 
 const SessionDetailGroupOptions = ({
   exercise,
+  exerciseOrder,
   details,
   loadExercises,
   reload,
   updateMultipleDetailsInGroups,
   removeMultipleDetailsInGroup,
-}: SessionDetailGroupOptions) => {
+  reorderExerciseOrderAfterDelete,
+}: SessionDetailGroupOptionsProps) => {
   const [unit, setUnit] = useState<(typeof units)[number]>(
     details[0]?.weightUnit || "kg"
   );
+  console.log(reorderExerciseOrderAfterDelete);
   const [currentWeights, setCurrentWeights] = useState<number[]>(
     details.map((d) => d.weight || 0)
   );
@@ -83,6 +85,7 @@ const SessionDetailGroupOptions = ({
       } else {
         await routineDetailService.deleteRoutineDetails(details);
       }
+      await reorderExerciseOrderAfterDelete(exerciseOrder);
       removeMultipleDetailsInGroup(details);
     } catch (e) {
       console.error(

--- a/src/app/(main)/_shared/session/exerciseGroup/SessionExerciseGroup.spec.tsx
+++ b/src/app/(main)/_shared/session/exerciseGroup/SessionExerciseGroup.spec.tsx
@@ -118,6 +118,7 @@ describe("SessionExerciseGroup", () => {
   const mockAddDetailToGroup = jest.fn();
   const mockUpdateDetailInGroups = jest.fn();
   const mockRemoveDetailFromGroup = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -157,6 +158,8 @@ describe("SessionExerciseGroup", () => {
     const defaultProps: SessionExerciseGroupProps = {
       details: mockWDs,
       exerciseOrder: mockExerciseOrder,
+
+      removeMultipleDetailsInGroup: jest.fn(),
       reload: mockReload,
       reorderAfterDelete: mockReorderAfterDelete,
       occurrence: 1,

--- a/src/app/(main)/_shared/session/exerciseGroup/SessionExerciseGroup.spec.tsx
+++ b/src/app/(main)/_shared/session/exerciseGroup/SessionExerciseGroup.spec.tsx
@@ -16,11 +16,14 @@ import { LocalExercise, Saved } from "@/types/models";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { getGroupedDetails } from "@/app/(main)/workout/_utils/getGroupedDetails";
+import { useSessionData } from "@/app/(main)/_shared/session/SessionContainer";
+import { createMockSessionData } from "@/test-utils/mocks/sessionData.mock";
 
 jest.mock("@/lib/di");
 jest.mock("@/providers/contexts/BottomSheetContext");
 jest.mock("@/providers/contexts/ModalContext");
 jest.mock("@/app/(main)/workout/_utils/getGroupedDetails");
+jest.mock("@/app/(main)/_shared/session/SessionContainer");
 
 const mockedExerciseService = jest.mocked(exerciseService);
 const mockedWorkoutDetailService = jest.mocked(workoutDetailService);
@@ -28,6 +31,7 @@ const mockedRoutineDetailService = jest.mocked(routineDetailService);
 const mockedUseModal = jest.mocked(useModal);
 const mockedUseBottomSheet = jest.mocked(useBottomSheet);
 const mockedGetGroupedDetails = jest.mocked(getGroupedDetails);
+const mockedUseSessionData = jest.mocked(useSessionData);
 
 const mockEx: Saved<LocalExercise> = {
   ...mockExercise.bookmarked,
@@ -135,6 +139,14 @@ describe("SessionExerciseGroup", () => {
       openModal: jest.fn(),
     });
 
+    mockedUseSessionData.mockReturnValue(
+      createMockSessionData({
+        updateDetailInGroups: mockUpdateDetailInGroups,
+        addDetailToGroup: mockAddDetailToGroup,
+        removeDetailFromGroup: mockRemoveDetailFromGroup,
+      })
+    );
+
     mockedExerciseService.getExerciseWithLocalId.mockResolvedValue(mockEx);
     mockedWorkoutDetailService.getLatestWorkoutDetailByDetail.mockResolvedValue(
       mockWDs[0]
@@ -158,15 +170,7 @@ describe("SessionExerciseGroup", () => {
     const defaultProps: SessionExerciseGroupProps = {
       details: mockWDs,
       exerciseOrder: mockExerciseOrder,
-
-      removeMultipleDetailsInGroup: jest.fn(),
-      reload: mockReload,
-      reorderAfterDelete: mockReorderAfterDelete,
       occurrence: 1,
-      updateDetailInGroups: jest.fn(),
-      updateMultipleDetailsInGroups: jest.fn(),
-      removeDetailFromGroup: mockRemoveDetailFromGroup,
-      addDetailToGroup: mockAddDetailToGroup,
     };
     render(<SessionExerciseGroup {...defaultProps} {...props} />);
   };
@@ -280,10 +284,11 @@ describe("SessionExerciseGroup", () => {
       expect(children.props).toEqual(
         expect.objectContaining({
           reload: expect.any(Function),
-          reorderAfterDelete: expect.any(Function),
           loadExercises: expect.any(Function),
           details: mockWDs,
           exercise: mockEx,
+          updateMultipleDetailsInGroups: expect.any(Function),
+          removeMultipleDetailsInGroup: expect.any(Function),
         })
       );
     });

--- a/src/app/(main)/_shared/session/exerciseGroup/SessionExerciseGroup.tsx
+++ b/src/app/(main)/_shared/session/exerciseGroup/SessionExerciseGroup.tsx
@@ -30,6 +30,9 @@ export type SessionExerciseGroupProps = {
     lastDetail: Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>
   ) => void;
   removeDetailFromGroup: (detailId: number) => void;
+  removeMultipleDetailsInGroup: (
+    details: Saved<LocalWorkoutDetail>[] | Saved<LocalRoutineDetail>[]
+  ) => void;
 };
 
 const SessionExerciseGroup = ({
@@ -42,6 +45,7 @@ const SessionExerciseGroup = ({
   updateMultipleDetailsInGroups,
   addDetailToGroup,
   removeDetailFromGroup,
+  removeMultipleDetailsInGroup,
 }: SessionExerciseGroupProps) => {
   const { openBottomSheet } = useBottomSheet();
   const lastDetail = details[details.length - 1];
@@ -112,7 +116,8 @@ const SessionExerciseGroup = ({
           </h6>
           <div className="flex items-center gap-1.5 text-xs text-text-muted mt-1">
             <span className="font-normal">
-              {currentVolume.toLocaleString()}{groupUnit}
+              {currentVolume.toLocaleString()}
+              {groupUnit}
             </span>
             {prevWorkoutDetails && volumeDiff !== 0 && (
               <span
@@ -121,7 +126,8 @@ const SessionExerciseGroup = ({
                 }`}
               >
                 {volumeDiff > 0 ? "+" : ""}
-                {volumeDiff.toLocaleString()}{groupUnit}
+                {volumeDiff.toLocaleString()}
+                {groupUnit}
               </span>
             )}
           </div>
@@ -133,6 +139,7 @@ const SessionExerciseGroup = ({
               minHeight: 300,
               children: (
                 <SessionDetailGroupOptions
+                  removeMultipleDetailsInGroup={removeMultipleDetailsInGroup}
                   reload={reload}
                   reorderAfterDelete={reorderAfterDelete}
                   loadExercises={reloadExercise}

--- a/src/app/(main)/_shared/session/sessionSet/SessionItem.spec.tsx
+++ b/src/app/(main)/_shared/session/sessionSet/SessionItem.spec.tsx
@@ -1,26 +1,32 @@
 jest.mock("@/providers/contexts/ModalContext");
+jest.mock("@/app/(main)/_shared/session/SessionContainer");
 jest.mock("@/lib/di");
 
 import { mockExercise } from "@/__mocks__/exercise.mock";
 import { mockRoutineDetail } from "@/__mocks__/routineDetail.mock";
 import { mockWorkoutDetail } from "@/__mocks__/workoutDetail.mock";
+import { useSessionData } from "@/app/(main)/_shared/session/SessionContainer";
 import SessionItem, {
   SessionItemProps,
 } from "@/app/(main)/_shared/session/sessionSet/SessionItem";
 
 import { routineDetailService, workoutDetailService } from "@/lib/di";
 import { useModal } from "@/providers/contexts/ModalContext";
+import { createMockSessionData } from "@/test-utils/mocks/sessionData.mock";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const mockUseModal = jest.mocked(useModal);
 const mockWorkoutDetailService = jest.mocked(workoutDetailService);
 const mockRoutineDetailService = jest.mocked(routineDetailService);
+const mockUseSessionData = jest.mocked(useSessionData);
 
 describe("SessionItem", () => {
   const mockShowError = jest.fn();
+
   const mockReload = jest.fn();
-  const mockReorder = jest.fn();
+  const mockReorderExerciseOrderAfterDelete = jest.fn();
+  const mockReorderSetOrderAfterDelete = jest.fn();
   const mockUpdateDetailInGroups = jest.fn();
   const mockRemoveDetailFromGroup = jest.fn();
 
@@ -28,7 +34,10 @@ describe("SessionItem", () => {
   const mockRD = mockRoutineDetail.past;
   const mockEx = mockExercise.bookmarked;
   const mockPrevWD = { ...mockWorkoutDetail.past, weight: 100, reps: 10 };
-
+  const mockGroup = {
+    exerciseOrder: 1,
+    details: [mockWD],
+  };
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseModal.mockReturnValue({
@@ -37,17 +46,24 @@ describe("SessionItem", () => {
       closeModal: jest.fn(),
       isOpen: false,
     });
+
+    mockUseSessionData.mockReturnValue(
+      createMockSessionData({
+        reorderExerciseOrderAfterDelete: mockReorderExerciseOrderAfterDelete,
+        reorderSetOrderAfterDelete: mockReorderSetOrderAfterDelete,
+        updateDetailInGroups: mockUpdateDetailInGroups,
+        removeDetailFromGroup: mockRemoveDetailFromGroup,
+        reload: mockReload,
+      })
+    );
   });
 
   const renderWorkoutItem = (props?: Partial<SessionItemProps>) => {
     const defaultProps: SessionItemProps = {
-      exercise: mockEx,
       detail: mockWD,
-      updateDetailInGroups: mockUpdateDetailInGroups,
-      removeDetailFromGroup: mockRemoveDetailFromGroup,
       prevWorkoutDetail: mockPrevWD,
-      reorderAfterDelete: mockReorder,
-      reload: mockReload,
+      group: mockGroup,
+      isLastSet: false,
     };
 
     render(<SessionItem {...defaultProps} {...props} />);
@@ -167,19 +183,60 @@ describe("SessionItem", () => {
       ).not.toHaveBeenCalled();
     });
 
-    it("루틴의 경우 삭제 버튼을 클릭하면 루틴 상세 삭제 후 재정렬 후 리로드한다", async () => {
-      renderWorkoutItem({ detail: mockRD });
+    describe("루틴 세트 삭제", () => {
+      it("루틴의 경우 삭제 버튼을 클릭하면 루틴 상세 삭제 후 재정렬 후 리로드한다", async () => {
+        renderWorkoutItem({ detail: mockRD });
 
-      const deleteButton = screen.getByRole("button", { name: "삭제" });
-      await user.click(deleteButton);
+        const deleteButton = screen.getByRole("button", { name: "삭제" });
+        await user.click(deleteButton);
 
-      expect(mockRoutineDetailService.deleteRoutineDetail).toHaveBeenCalledWith(
-        mockRD.id
-      );
-      expect(mockReorder).toHaveBeenCalledWith(mockRD.exerciseOrder);
-      expect(mockRemoveDetailFromGroup).toHaveBeenCalledWith(mockRD.id);
+        expect(
+          mockRoutineDetailService.deleteRoutineDetail
+        ).toHaveBeenCalledWith(mockRD.id);
+        expect(mockRemoveDetailFromGroup).toHaveBeenCalledWith(mockRD.id);
+      });
+
+      it("삭제된 세트가 해당 그룹의 마지막세트이면 exerciseOrder를 재정렬한다", async () => {
+        const mockGroup = {
+          exerciseOrder: 123,
+          details: [mockRD],
+        };
+        renderWorkoutItem({
+          detail: mockRD,
+          group: mockGroup,
+          isLastSet: true,
+        });
+
+        const deleteButton = screen.getByRole("button", { name: "삭제" });
+        await user.click(deleteButton);
+
+        expect(
+          mockRoutineDetailService.deleteRoutineDetail
+        ).toHaveBeenCalledWith(mockRD.id);
+        expect(mockRemoveDetailFromGroup).toHaveBeenCalledWith(mockRD.id);
+        expect(mockReorderExerciseOrderAfterDelete).toHaveBeenCalledWith(123);
+        expect(mockReorderSetOrderAfterDelete).not.toHaveBeenCalled();
+      });
+
+      it("삭제된 세트가 해당 그룹의 마지막세트가 아니면 setOrder를 재정렬한다", async () => {
+        renderWorkoutItem({
+          detail: mockRD,
+        });
+
+        const deleteButton = screen.getByRole("button", { name: "삭제" });
+        await user.click(deleteButton);
+
+        expect(
+          mockRoutineDetailService.deleteRoutineDetail
+        ).toHaveBeenCalledWith(mockRD.id);
+        expect(mockRemoveDetailFromGroup).toHaveBeenCalledWith(mockRD.id);
+        expect(mockReorderSetOrderAfterDelete).toHaveBeenCalledWith(
+          mockRD.exerciseId,
+          mockRD.setOrder
+        );
+        expect(mockReorderExerciseOrderAfterDelete).not.toHaveBeenCalled();
+      });
     });
-
     it("무게나 횟수 업데이트 도중 에러가 발생하면 에러 모달을 표시한다 (workoutDetail)", async () => {
       mockWorkoutDetailService.updateLocalWorkoutDetail.mockRejectedValue(
         new Error("업데이트 실패")

--- a/src/app/(main)/_shared/session/sessionSet/SetActions.spec.tsx
+++ b/src/app/(main)/_shared/session/sessionSet/SetActions.spec.tsx
@@ -1,19 +1,23 @@
 jest.mock("@/lib/di");
 jest.mock("@/providers/contexts/ModalContext");
+jest.mock("@/app/(main)/_shared/session/SessionContainer");
 
 import { mockRoutineDetail } from "@/__mocks__/routineDetail.mock";
 import { mockWorkoutDetail } from "@/__mocks__/workoutDetail.mock";
+import { useSessionData } from "@/app/(main)/_shared/session/SessionContainer";
 import SetActions, {
   SetActionsProps,
 } from "@/app/(main)/_shared/session/sessionSet/SetActions";
 import { routineDetailService, workoutDetailService } from "@/lib/di";
 import { useModal } from "@/providers/contexts/ModalContext";
+import { createMockSessionData } from "@/test-utils/mocks/sessionData.mock";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const mockWorkoutDetailService = jest.mocked(workoutDetailService);
 const mockRoutineDetailService = jest.mocked(routineDetailService);
 const mockUseModal = jest.mocked(useModal);
+const mockUseSessionData = jest.mocked(useSessionData);
 
 describe("SetActions", () => {
   const mockShowError = jest.fn();
@@ -22,6 +26,7 @@ describe("SetActions", () => {
   const mockRD = { ...mockRoutineDetail.past, id: 600 };
   const mockAddDetailToGroup = jest.fn();
   const mockRemoveDetailFromGroup = jest.fn();
+  const mockReorderExerciseOrderAfterDelete = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -31,13 +36,20 @@ describe("SetActions", () => {
       closeModal: jest.fn(),
       isOpen: false,
     });
+
+    mockUseSessionData.mockReturnValue(
+      createMockSessionData({
+        reorderExerciseOrderAfterDelete: mockReorderExerciseOrderAfterDelete,
+        addDetailToGroup: mockAddDetailToGroup,
+        removeDetailFromGroup: mockRemoveDetailFromGroup,
+      })
+    );
   });
 
   const renderSetActions = (props?: Partial<SetActionsProps>) => {
     const defaultProps: SetActionsProps = {
       lastValue: mockWD,
-      addDetailToGroup: mockAddDetailToGroup,
-      removeDetailFromGroup: mockRemoveDetailFromGroup,
+      exerciseOrder: 5,
     };
     render(<SetActions {...defaultProps} {...props} />);
   };
@@ -124,6 +136,7 @@ describe("SetActions", () => {
       );
 
       expect(mockRemoveDetailFromGroup).toHaveBeenCalledWith(mockRD.id);
+      expect(mockReorderExerciseOrderAfterDelete).toHaveBeenCalledWith(5);
 
       expect(
         mockWorkoutDetailService.deleteWorkoutDetail

--- a/src/app/(main)/_shared/session/sessionSet/SetActions.tsx
+++ b/src/app/(main)/_shared/session/sessionSet/SetActions.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSessionData } from "@/app/(main)/_shared/session/SessionContainer";
 import { isWorkoutDetail } from "@/app/(main)/workout/_utils/checkIsWorkoutDetails";
 import { routineDetailService, workoutDetailService } from "@/lib/di";
 import { useModal } from "@/providers/contexts/ModalContext";
@@ -8,19 +9,16 @@ import { LocalRoutineDetail, LocalWorkoutDetail, Saved } from "@/types/models";
 
 export type SetActionsProps = {
   lastValue: Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>;
-  addDetailToGroup: (
-    newDetail: Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>,
-    lastDetail: Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>
-  ) => void;
-  removeDetailFromGroup: (detailId: number) => void;
+  exerciseOrder: number;
 };
 
-const SetActions = ({
-  lastValue,
-  addDetailToGroup,
-  removeDetailFromGroup,
-}: SetActionsProps) => {
+const SetActions = ({ lastValue, exerciseOrder }: SetActionsProps) => {
   const { showError } = useModal();
+  const {
+    reorderExerciseOrderAfterDelete,
+    addDetailToGroup,
+    removeDetailFromGroup,
+  } = useSessionData();
   const handleAddSet = async () => {
     try {
       let newDetail: Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>;
@@ -46,6 +44,9 @@ const SetActions = ({
         await routineDetailService.deleteRoutineDetail(detailId);
       }
 
+      if (lastValue.setOrder === 1) {
+        await reorderExerciseOrderAfterDelete(exerciseOrder);
+      }
       removeDetailFromGroup(detailId);
     } catch (e) {
       console.error("[SetActions] Error", e);

--- a/src/hooks/useLoadDetails.ts
+++ b/src/hooks/useLoadDetails.ts
@@ -280,6 +280,23 @@ const useLoadDetails = ({
     []
   );
 
+  const removeMultipleDetailsInGroup = useCallback(
+    (details: Saved<LocalWorkoutDetail>[] | Saved<LocalRoutineDetail>[]) => {
+      setWorkoutGroups((prevGroups) =>
+        prevGroups
+          .filter(
+            (group) =>
+              !details.some((d) => group.details.some((g) => g.id === d.id))
+          )
+          .map((group, idx) => ({
+            ...group,
+            exerciseOrder: idx + 1,
+          }))
+      );
+    },
+    []
+  );
+
   return {
     error,
     isLoading: isInitialLoading,
@@ -293,6 +310,7 @@ const useLoadDetails = ({
     addDetailToGroup,
     removeDetailFromGroup,
     updateMultipleDetailsInGroups,
+    removeMultipleDetailsInGroup,
   };
 };
 

--- a/src/test-utils/mocks/sessionData.mock.ts
+++ b/src/test-utils/mocks/sessionData.mock.ts
@@ -1,0 +1,51 @@
+import { SessionData } from "@/app/(main)/_shared/session/SessionContainer";
+import { LocalRoutineDetail, LocalWorkoutDetail, Saved } from "@/types/models";
+
+export type SessionDataMock = {
+  updateDetailInGroups: jest.Mock;
+  updateMultipleDetailsInGroups: jest.Mock;
+  addDetailToGroup: jest.Mock;
+  removeDetailFromGroup: jest.Mock;
+  removeMultipleDetailsInGroup: jest.Mock;
+  reorderAfterDelete: jest.Mock;
+  reorderExerciseOrderAfterDelete: jest.Mock;
+  reorderSetOrderAfterDelete: jest.Mock;
+  sessionGroup: Array<{
+    exerciseOrder: number;
+    details: Array<Saved<LocalWorkoutDetail> | Saved<LocalRoutineDetail>>;
+  }>;
+};
+
+export const createMockSessionData = (
+  overrides?: Partial<SessionData>
+): SessionData => {
+  return {
+    updateDetailInGroups: jest.fn(),
+    updateMultipleDetailsInGroups: jest.fn(),
+    addDetailToGroup: jest.fn(),
+    removeDetailFromGroup: jest.fn(),
+    removeMultipleDetailsInGroup: jest.fn(),
+    reload: jest.fn(),
+    reorderExerciseOrderAfterDelete: jest.fn(),
+    reorderSetOrderAfterDelete: jest.fn(),
+    sessionGroup: [],
+    ...overrides,
+  };
+};
+
+export const setupSessionDataMock = () => {
+  const mockUseSessionData = jest.fn();
+  const defaultMock = createMockSessionData();
+
+  mockUseSessionData.mockReturnValue(defaultMock);
+
+  return {
+    mockUseSessionData,
+    defaultMock,
+    updateMock: (overrides: Partial<SessionData>) => {
+      const newMock = createMockSessionData(overrides);
+      mockUseSessionData.mockReturnValue(newMock);
+      return newMock;
+    },
+  };
+};


### PR DESCRIPTION
## 변경 사항:

- session group 을 삭제하면 details 전체가 리렌더링되어 최상단으로 스크롤되는 문제 개선
- context api 패턴을 통해 props drillilng 완화
- detail 또는 group 삭제시에 db의 exerciseOrder및 setOrder가 올바르게 갱신되지 않는문제 해결

## 변경 유형

- [x] 버그 수정
- [ ] 신규 기능
- [x] 테스트코드 작성
- [ ] 코드 스타일 개선 (포매팅, 로컬 변수 이름 변경 등)
- [x] 리팩토링 (기능적 변경 없이 코드 개선)
- [ ] 문서 내용 변경
- [ ] 기타 (아래에 설명 추가)

## 체크리스트:

PR을 완료하기 전에 다음 항목들을 확인하고 체크하세요:

- [x] 이 코드가 프로젝트의 기존 코드 스타일을 따르는지 확인했습니다.
- [x] 이 변경 사항이 빌드 오류 없이 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어가 이해할 수 있도록 충분한 설명을 추가했습니다.

## 관련 이슈
close #115 
close #118
